### PR TITLE
fix: case for default key with no suffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,30 +14,35 @@ module.exports = plugin(function ({ addUtilities, theme, matchUtilities, addComp
         white: 'var(--color-text-white)',
         black: 'var(--color-text-black)',
         interactive: {
+          default: 'var(--color-text-interactive-default)', // retained for back compat
           DEFAULT: 'var(--color-text-interactive-default)',
           hover: 'var(--color-text-interactive-hover)'
         }
       },
       backgroundColor: {
         base: {
+          default: 'var(--color-background-base-default)', // retained for back compat
           DEFAULT: 'var(--color-background-base-default)',
           header: 'var(--color-background-base-header)',
           hover: 'var(--color-background-base-hover)',
           selected: 'var(--color-background-base-selected)'
         },
         surface: {
+          default: 'var(--color-background-surface-default)', // retained for back compat
           DEFAULT: 'var(--color-background-surface-default)',
           header: 'var(--color-background-surface-header)',
           hover: 'var(--color-background-surface-hover)',
           selected: 'var(--color-background-surface-selected)'
         },
         interactive: {
+          default: 'var(--color-background-interactive-default)', // retained for back compat
           DEFAULT: 'var(--color-background-interactive-default)',
           hover: 'var(--color-background-interactive-hover)'
         }
       },
       borderColor: {
         interactive: {
+          default: 'var(--color-border-interactive-default)', // retained for back compat
           DEFAULT: 'var(--color-border-interactive-default)',
           hover: 'var(--color-border-interactive-hover)',
           muted: 'var(--color-border-interactive-muted)'

--- a/index.js
+++ b/index.js
@@ -14,31 +14,31 @@ module.exports = plugin(function ({ addUtilities, theme, matchUtilities, addComp
         white: 'var(--color-text-white)',
         black: 'var(--color-text-black)',
         interactive: {
-          default: 'var(--color-text-interactive-default)',
+          DEFAULT: 'var(--color-text-interactive-default)',
           hover: 'var(--color-text-interactive-hover)'
         }
       },
       backgroundColor: {
         base: {
-          default: 'var(--color-background-base-default)',
+          DEFAULT: 'var(--color-background-base-default)',
           header: 'var(--color-background-base-header)',
           hover: 'var(--color-background-base-hover)',
           selected: 'var(--color-background-base-selected)'
         },
         surface: {
-          default: 'var(--color-background-surface-default)',
+          DEFAULT: 'var(--color-background-surface-default)',
           header: 'var(--color-background-surface-header)',
           hover: 'var(--color-background-surface-hover)',
           selected: 'var(--color-background-surface-selected)'
         },
         interactive: {
-          default: 'var(--color-background-interactive-default)',
+          DEFAULT: 'var(--color-background-interactive-default)',
           hover: 'var(--color-background-interactive-hover)'
         }
       },
       borderColor: {
         interactive: {
-          default: 'var(--color-border-interactive-default)',
+          DEFAULT: 'var(--color-border-interactive-default)',
           hover: 'var(--color-border-interactive-hover)',
           muted: 'var(--color-border-interactive-muted)'
         }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,11 @@ module.exports = plugin(function ({ addUtilities, theme, matchUtilities, addComp
 }, {
   theme: {
     extend: {
+      // Like many other places in Tailwind, the special DEFAULT key can be used when you want to define a value with no suffix
+      // https://tailwindcss.com/docs/customizing-colors
+      // 
+      // Below, default and DEFAULT exist in some cases to maintain backward compatibility.   
+      // In a major version bump `default` can be dropped, though it will be a breaking change if anyone is depending on `-default`
       textColor: {
         primary: 'var(--color-text-primary)',
         secondary: 'var(--color-text-secondary)',
@@ -14,35 +19,35 @@ module.exports = plugin(function ({ addUtilities, theme, matchUtilities, addComp
         white: 'var(--color-text-white)',
         black: 'var(--color-text-black)',
         interactive: {
-          default: 'var(--color-text-interactive-default)', // retained for back compat
+          default: 'var(--color-text-interactive-default)',
           DEFAULT: 'var(--color-text-interactive-default)',
           hover: 'var(--color-text-interactive-hover)'
         }
       },
       backgroundColor: {
         base: {
-          default: 'var(--color-background-base-default)', // retained for back compat
+          default: 'var(--color-background-base-default)',
           DEFAULT: 'var(--color-background-base-default)',
           header: 'var(--color-background-base-header)',
           hover: 'var(--color-background-base-hover)',
           selected: 'var(--color-background-base-selected)'
         },
         surface: {
-          default: 'var(--color-background-surface-default)', // retained for back compat
+          default: 'var(--color-background-surface-default)',
           DEFAULT: 'var(--color-background-surface-default)',
           header: 'var(--color-background-surface-header)',
           hover: 'var(--color-background-surface-hover)',
           selected: 'var(--color-background-surface-selected)'
         },
         interactive: {
-          default: 'var(--color-background-interactive-default)', // retained for back compat
+          default: 'var(--color-background-interactive-default)',
           DEFAULT: 'var(--color-background-interactive-default)',
           hover: 'var(--color-background-interactive-hover)'
         }
       },
       borderColor: {
         interactive: {
-          default: 'var(--color-border-interactive-default)', // retained for back compat
+          default: 'var(--color-border-interactive-default)',
           DEFAULT: 'var(--color-border-interactive-default)',
           hover: 'var(--color-border-interactive-hover)',
           muted: 'var(--color-border-interactive-muted)'


### PR DESCRIPTION
Tailwind cares that this is `DEFAULT` and not `default`

If you try to use one of the "default" colors eg `bg-base` you'll get nothing in return (though `bg-base-default` will work).

> Like many other places in Tailwind, the special `DEFAULT` key can be used when you want to define a value with no suffix:

```
/** @type {import('tailwindcss').Config} */
module.exports = {
  theme: {
    colors: {
      // ...
      'tahiti': {
        light: '#67e8f9',
        DEFAULT: '#06b6d4',
        dark: '#0e7490',
      },
      // ...
    },
  },
}
```

https://tailwindcss.com/docs/customizing-colors

-----

edit: we should just _add_ DEFAULT but not remove `default` unless we want to major version bump.